### PR TITLE
Fix quiz selection carry-over

### DIFF
--- a/fe/ddobagi/src/components/Word/ReviewQuiz.tsx
+++ b/fe/ddobagi/src/components/Word/ReviewQuiz.tsx
@@ -87,6 +87,11 @@ const ReviewQuiz: React.FC<QuizProps> = ({
     fetchData();
   }, [userId, quizId]);
 
+  // 퀴즈가 변경되면 이전에 선택한 답안을 초기화한다.
+  useEffect(() => {
+    setSelectedOption("");
+  }, [quizId]);
+
   if (!quizData) {
     return <div>Loading...</div>;
   }

--- a/fe/ddobagi/src/components/Word/WordQuiz.tsx
+++ b/fe/ddobagi/src/components/Word/WordQuiz.tsx
@@ -103,6 +103,11 @@ const Quiz: React.FC<QuizProps> = ({
     fetchData();
   }, [userId, quizId]);
 
+  // 새 퀴즈가 로딩될 때 선택된 답안을 초기화한다.
+  useEffect(() => {
+    setSelectedOption("");
+  }, [quizId]);
+
   if (!quizData) {
     return <div>Loading...</div>;
   }


### PR DESCRIPTION
## Summary
- reset previously chosen option when next quiz loads

## Testing
- `npm test -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f8067d6c832d9d8c7dc6776caca5